### PR TITLE
Corrects issue with collectd[:version] being misapplied for package installations

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,8 @@
 ---
 driver_plugin: vagrant
+driver_config:
+  require_chef_omnibus: latest
+
 platforms:
 - name: ubuntu-12.04
   driver_config:
@@ -29,6 +32,7 @@ suites:
 - name: default
   run_list:
   - recipe[collectd]
+  - recipe[minitest-handler]
   attributes: {}
 - name: databag
   run_list:

--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,4 @@ site :opscode
 metadata
 cookbook 'apt'
 cookbook 'yum'
+cookbook 'minitest-handler', '~> 1.0'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,10 +16,10 @@
 
 default['collectd']['interval'] = 10
 default['collectd']['read_threads'] = 5
-default['collectd']['version'] = "5.1.0"
+default['collectd']['install_type'] = "package"
+default['collectd']['version'] = "5.1.0" unless node['collectd']['install_type'] == 'package'
 default['collectd']['fqdn_lookup'] = "false"
 default['collectd']['server_role'] = "collectd-server"
-default['collectd']['install_type'] = "package"
 default['collectd']['source_tar_name_prefix'] = "collectd-"
 default['collectd']['source_tar_name_extension'] = ".tar.gz"
 default['collectd']['source_url_prefix'] = "http://collectd.org/files/"

--- a/files/default/tests/minitest/client_test.rb
+++ b/files/default/tests/minitest/client_test.rb
@@ -11,12 +11,6 @@ describe 'collectd::client' do
     service('collectd').must_be_enabled
   end
 
-  describe 'collectd::_install_from_package' do
-    it 'installs collectd' do
-      package('collectd').must_be_installed
-    end
-  end
-
   describe 'collectd::_server_conf' do
     it 'creates the sysconf_dir' do
       directory(node['collectd']['sysconf_dir']).must_exist
@@ -38,5 +32,4 @@ describe 'collectd::client' do
       collectd_config_parses?
     end
   end
-
 end

--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -1,0 +1,25 @@
+require File.expand_path('../support/helpers', __FILE__)
+
+describe 'collectd::client' do
+  include Helpers::Collectd
+
+  describe 'collectd::_install_from_package' do
+    it 'installs collectd' do
+      package('collectd').must_be_installed
+    end
+
+    it 'installs the correct version of collectd' do
+      case node['platform_family']
+      when 'debian'
+        get_version = "dpkg-query -W -f='${Version}' collectd"
+      when 'rhel'
+        get_version = "rpm -q collectd --queryformat %{VERSION}"
+      else
+        get_version = "echo unsupported #{platform_family}, good luck."
+      end
+      actual = assert_sh(get_version)
+      assert_equal node['collectd']['version'], actual if node['collectd']['version']
+    end
+
+  end
+end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -15,12 +15,7 @@
 # limitations under the License.
 #
 
-case node['collectd']['install_type']
-when 'source'
-  include_recipe "collectd::_install_from_source"
-when 'package'
-  include_recipe "collectd::_install_from_package"
-end
+include_recipe 'collectd'
 
 include_recipe "collectd::_server_conf"
 


### PR DESCRIPTION
Package installations for RHEL & Ubuntu still install collectd4, despite the default collectd[:version] = "5.1.0" in attributes. This causes at least write_graphite to behave incorrectly.

This PR corrects this and adds tests.
